### PR TITLE
Blacklist Wallet Clarity Smart Contract

### DIFF
--- a/super_fun_contrat/Clarinet.toml
+++ b/super_fun_contrat/Clarinet.toml
@@ -5,6 +5,11 @@ authors = []
 telemetry = true
 cache_dir = '.\.cache'
 requirements = []
+[contracts.blacklist_wallet]
+path = 'contracts/blacklist_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.file_tagging]
 path = 'contracts/file_tagging.clar'
 clarity_version = 2

--- a/super_fun_contrat/contracts/blacklist_wallet.clar
+++ b/super_fun_contrat/contracts/blacklist_wallet.clar
@@ -1,0 +1,161 @@
+;; Blacklist Wallet Smart Contract
+;; This contract manages a blacklist of addresses and prevents blacklisted users from depositing or withdrawing
+
+;; Error constants
+(define-constant ERR_UNAUTHORIZED (err u401))
+(define-constant ERR_BLACKLISTED (err u403))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u404))
+(define-constant ERR_INVALID_AMOUNT (err u400))
+
+;; Contract owner (deployer)
+(define-constant CONTRACT_OWNER tx-sender)
+
+;; Data variables
+(define-data-var total-deposits uint u0)
+
+;; Data maps
+;; Track blacklisted addresses
+(define-map blacklisted-addresses principal bool)
+
+;; Track user balances
+(define-map user-balances principal uint)
+
+;; Private functions
+
+;; Check if a user is blacklisted
+(define-private (is-blacklisted (user principal))
+    (default-to false (map-get? blacklisted-addresses user))
+)
+
+;; Public functions
+
+;; Add an address to the blacklist (only contract owner can call this)
+(define-public (add-to-blacklist (user principal))
+    (begin
+        ;; Check if caller is the contract owner
+        (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+        
+        ;; Add user to blacklist
+        (map-set blacklisted-addresses user true)
+        
+        (ok true)
+    )
+)
+
+;; Remove an address from the blacklist (only contract owner can call this)
+(define-public (remove-from-blacklist (user principal))
+    (begin
+        ;; Check if caller is the contract owner
+        (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+        
+        ;; Remove user from blacklist
+        (map-delete blacklisted-addresses user)
+        
+        (ok true)
+    )
+)
+
+;; Deposit STX tokens (blocked if blacklisted)
+(define-public (deposit (amount uint))
+    (let (
+        (current-balance (default-to u0 (map-get? user-balances tx-sender)))
+    )
+        ;; Check if amount is valid
+        (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+        
+        ;; Check if user is not blacklisted
+        (asserts! (not (is-blacklisted tx-sender)) ERR_BLACKLISTED)
+        
+        ;; Transfer STX from user to contract
+        (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+        
+        ;; Update user balance
+        (map-set user-balances tx-sender (+ current-balance amount))
+        
+        ;; Update total deposits
+        (var-set total-deposits (+ (var-get total-deposits) amount))
+        
+        (ok amount)
+    )
+)
+
+;; Withdraw STX tokens (blocked if blacklisted)
+(define-public (withdraw (amount uint))
+    (let (
+        (current-balance (default-to u0 (map-get? user-balances tx-sender)))
+    )
+        ;; Check if amount is valid
+        (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+        
+        ;; Check if user is not blacklisted
+        (asserts! (not (is-blacklisted tx-sender)) ERR_BLACKLISTED)
+        
+        ;; Check if user has sufficient balance
+        (asserts! (>= current-balance amount) ERR_INSUFFICIENT_BALANCE)
+        
+        ;; Update user balance
+        (map-set user-balances tx-sender (- current-balance amount))
+        
+        ;; Update total deposits
+        (var-set total-deposits (- (var-get total-deposits) amount))
+        
+        ;; Transfer STX from contract to user
+        (try! (as-contract (stx-transfer? amount tx-sender tx-sender)))
+        
+        (ok amount)
+    )
+)
+
+;; Emergency withdrawal by contract owner (bypasses blacklist for contract owner only)
+(define-public (emergency-withdraw (user principal) (amount uint))
+    (let (
+        (current-balance (default-to u0 (map-get? user-balances user)))
+    )
+        ;; Check if caller is the contract owner
+        (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
+        
+        ;; Check if amount is valid
+        (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+        
+        ;; Check if user has sufficient balance
+        (asserts! (>= current-balance amount) ERR_INSUFFICIENT_BALANCE)
+        
+        ;; Update user balance
+        (map-set user-balances user (- current-balance amount))
+        
+        ;; Update total deposits
+        (var-set total-deposits (- (var-get total-deposits) amount))
+        
+        ;; Transfer STX from contract to user
+        (try! (as-contract (stx-transfer? amount tx-sender user)))
+        
+        (ok amount)
+    )
+)
+
+;; Read-only functions
+
+;; Check if an address is blacklisted
+(define-read-only (check-blacklist-status (user principal))
+    (is-blacklisted user)
+)
+
+;; Get user balance
+(define-read-only (get-balance (user principal))
+    (default-to u0 (map-get? user-balances user))
+)
+
+;; Get total deposits in the contract
+(define-read-only (get-total-deposits)
+    (var-get total-deposits)
+)
+
+;; Get contract owner
+(define-read-only (get-contract-owner)
+    CONTRACT_OWNER
+)
+
+;; Get contract's STX balance
+(define-read-only (get-contract-stx-balance)
+    (stx-get-balance (as-contract tx-sender))
+)

--- a/super_fun_contrat/tests/blacklist_wallet.test.ts
+++ b/super_fun_contrat/tests/blacklist_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Blacklist Wallet Smart Contract — README

## Overview

A small Clarity (Stacks) smart contract that manages a simple on-chain wallet with per-user balances and a blacklist. Blacklisted addresses are prevented from depositing or withdrawing. The contract also exposes owner-only management functions and an emergency withdrawal mechanism for the contract owner.

## Features

* Per-user STX balances (`user-balances`).
* Global `total-deposits` counter.
* Owner-managed blacklist (`blacklisted-addresses`).
* Deposit and withdraw entrypoints that block blacklisted users.
* Emergency withdrawal (owner only) that can bypass blacklist for recovery/administration.
* Read-only views for status and balances.

---

# Contract state & data

* `CONTRACT_OWNER` — constant set to the deploying principal (`tx-sender` at deploy time).
* `total-deposits` — `uint` data variable holding the total STX deposited to the contract.
* `blacklisted-addresses` — map from `principal` → `bool` showing whether an address is blacklisted.
* `user-balances` — map from `principal` → `uint` storing each user’s balance held in the contract.

---

# Error codes

The contract defines compact error constants used for `asserts!` failures:

* `ERR_UNAUTHORIZED` — `err u401` — caller is not the contract owner.
* `ERR_BLACKLISTED` — `err u403` — caller is blacklisted (blocked).
* `ERR_INSUFFICIENT_BALANCE` — `err u404` — user balance is too low for the operation.
* `ERR_INVALID_AMOUNT` — `err u400` — amount must be > 0.

---

# Public entrypoints (summary)

### `add-to-blacklist (user principal) -> (response bool uint)`

Owner-only. Adds `user` to the blacklist. Returns `true` on success.

**Checks**

* Caller must equal `CONTRACT_OWNER` (`ERR_UNAUTHORIZED`).

### `remove-from-blacklist (user principal) -> (response bool uint)`

Owner-only. Removes `user` from the blacklist. Returns `true` on success.

**Checks**

* Caller must equal `CONTRACT_OWNER` (`ERR_UNAUTHORIZED`).

### `deposit (amount uint) -> (response uint uint)`

Allows a user to deposit STX into the contract and increases their `user-balances` and `total-deposits`. Blocked when the caller is blacklisted.

**Checks**

* `amount > 0` (`ERR_INVALID_AMOUNT`)
* caller is **not** blacklisted (`ERR_BLACKLISTED`)
* performs STX transfer from user to contract
* updates `user-balances` and `total-deposits`

Returns the deposited `amount` on success.

### `withdraw (amount uint) -> (response uint uint)`

Allows a user to withdraw STX from their balance if not blacklisted.

**Checks**

* `amount > 0` (`ERR_INVALID_AMOUNT`)
* caller is **not** blacklisted (`ERR_BLACKLISTED`)
* caller has sufficient balance (`ERR_INSUFFICIENT_BALANCE`)
* updates `user-balances` and `total-deposits`
* transfers STX from contract to caller

Returns the withdrawn `amount` on success.

### `emergency-withdraw (user principal) (amount uint) -> (response uint uint)`

Owner-only emergency withdrawal for a target `user`. This entrypoint allows the owner to withdraw STX from `user`'s recorded balance and send it to `user` (useful for admin recovery actions).

**Checks**

* Caller must be `CONTRACT_OWNER` (`ERR_UNAUTHORIZED`)
* `amount > 0` (`ERR_INVALID_AMOUNT`)
* `user` has sufficient balance (`ERR_INSUFFICIENT_BALANCE`)
* updates `user-balances` and `total-deposits`
* transfers STX from contract to `user`

Returns the withdrawn `amount` on success.

---

# Read-only functions

* `check-blacklist-status (user principal) -> bool` — returns true if `user` is blacklisted.
* `get-balance (user principal) -> uint` — returns the stored balance (defaults to `u0`).
* `get-total-deposits () -> uint` — returns `total-deposits`.
* `get-contract-owner () -> principal` — returns the deployer/owner constant.
* `get-contract-stx-balance () -> uint` — attempts to return the contract’s STX balance (wrapper over `stx-get-balance`).

---

# Usage examples (pseudo-calls)

> Note: adapt these to whatever client / tooling you use (Clarity CLI, Clarinet tests, or a Stacks SDK).

* Add address to blacklist (owner call)

```
(try .call add-to-blacklist '<owner-principal>' '<target-principal>')
```

* Deposit 1000 uSTX (user call)

```
(try .call deposit '<user-principal>' u1000)
```

* Withdraw 500 uSTX (user call)

```
(try .call withdraw '<user-principal>' u500)
```

* Emergency withdraw (owner)

```
(try .call emergency-withdraw '<owner-principal>' '<target-principal>' u250)
```

* Read-only balance

```
(try .call-read get-balance '<target-principal>')
```

---

# Security considerations & notes

* **Owner power** — The `CONTRACT_OWNER` can add/remove addresses from the blacklist and call `emergency-withdraw`. Ensure private key safety and consider multisig or governance controls in production deployments.
* **Blacklisting** — Blacklisting prevents deposits and withdrawals but does not automatically liquidate balances. Keep an off-chain governance/audit log of blacklisting actions.
* **STX transfer correctness** — Carefully review and test the code paths that call `stx-transfer?` / `as-contract` to ensure tokens move exactly as intended. Unit tests and local Clarinet runs are recommended.
* **Reentrancy / atomicity** — Clarity is a decidable language designed to avoid common EVM-style reentrancy problems; still, test state updates and transfer ordering thoroughly in integration tests.
* **Access control** — Owner is defined at deployment as `tx-sender`. If you intend to support owner transfer, add an explicit `transfer-ownership` entrypoint.

---

# Recommended improvements / TODO

* Add an event log or map to track blacklist change timestamps and the reason for auditing.
* Add an explicit `pause`/`unpause` switch for emergency halting of deposits/withdrawals.
* Add `transfer-ownership` entrypoint to let the owner hand off privileges.
* Add unit tests (Clarinet) covering:

  * deposit / withdraw happy paths
  * blacklisted user behavior
  * owner-only protections and emergency withdraw
  * edge cases: zero amounts, balances exactly equal to withdrawal amount, etc.
* Consider implementing per-user deposit/withdrawal limits or a timelock for emergency withdraws if needed for governance.

---

# Deployment & testing (quick)

1. Install Clarinet (or your preferred Clarity toolchain).
2. Place the contract file in `contracts/` and run local tests.
3. Use `clarinet check` and `clarinet test` to run unit tests.
4. Deploy with your Stacks deployment mechanism (Stacks CLI / explorer), ensuring you set the deployer key for the intended contract owner.

---

# License

Apache-2.0.

---